### PR TITLE
Allow using MongoClientSettings instead of ConnectionString

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,27 @@ Install the nuget package
 
     PM> Install-Package MongoDbCache
 
-You can either choose to use the provided extension method or register the implementation in the ConfigureServices method:
+You can either choose to use the provided extension method or register the implementation in the ConfigureServices method.
+The mongo connection settings can be passed as either a connection string or MongoClientSettings object.
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {  
 	services.AddMongoDbCache(options => {
 		options.ConnectionString = "mongodb://localhost:27017",
+		options.DatabaseName = "MongoCache",
+		options.CollectionName = "appcache",
+		options.ExpiredScanInterval = TimeSpan.FromMinutes(10)
+	});
+}
+```
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{  
+    var mongoSettings = new MongoClientSettings();
+
+	services.AddMongoDbCache(options => {
+		options.MongoClientSettings = mongoSettings,
 		options.DatabaseName = "MongoCache",
 		options.CollectionName = "appcache",
 		options.ExpiredScanInterval = TimeSpan.FromMinutes(10)

--- a/src/MongoDbCache.Tests/Infrastructure/MongoDbCacheConfig.cs
+++ b/src/MongoDbCache.Tests/Infrastructure/MongoDbCacheConfig.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Caching.Distributed;
 using System;
+using MongoDB.Driver;
 
 namespace MongoDbCache.Tests.Infrastructure
 {
@@ -7,7 +8,10 @@ namespace MongoDbCache.Tests.Infrastructure
     {
         public static IDistributedCache CreateCacheInstance()
         {
-            return new MongoDbCache(CreateOptions());
+            var useMongoClientSettings =
+                Environment.GetEnvironmentVariable("MongoDbCacheTestsUseMongoClientSettings") == "true";
+            
+            return new MongoDbCache(useMongoClientSettings ? CreateOptionsWithMongoClientSettings() : CreateOptions());
         }
 
         public static MongoDbCacheOptions CreateOptions()
@@ -15,6 +19,20 @@ namespace MongoDbCache.Tests.Infrastructure
             return new MongoDbCacheOptions
             {
                 ConnectionString = "mongodb://localhost:27017",
+                DatabaseName = "MongoCache",
+                CollectionName = "appcache",
+                ExpiredScanInterval = TimeSpan.FromMinutes(10)
+            };
+        }
+
+        private static MongoDbCacheOptions CreateOptionsWithMongoClientSettings()
+        {
+            return new MongoDbCacheOptions
+            {
+                MongoClientSettings = new MongoClientSettings
+                {
+                    Server = MongoServerAddress.Parse("localhost")
+                },
                 DatabaseName = "MongoCache",
                 CollectionName = "appcache",
                 ExpiredScanInterval = TimeSpan.FromMinutes(10)

--- a/src/MongoDbCache/MongoContext.cs
+++ b/src/MongoDbCache/MongoContext.cs
@@ -83,9 +83,9 @@ namespace MongoDbCache
             return cacheItem.WithExpiresAt(absoluteExpiration);
         }
 
-        public MongoContext(string connectionString, string databaseName, string collectionName)
+        public MongoContext(string connectionString, MongoClientSettings mongoClientSettings, string databaseName, string collectionName)
         {
-            var client = new MongoClient(connectionString);
+            var client = mongoClientSettings == null ? new MongoClient(connectionString) : new MongoClient(mongoClientSettings);
             var database = client.GetDatabase(databaseName);
 
             IndexKeysDefinition<CacheItem> expireAtIndexModel =

--- a/src/MongoDbCache/MongoDbCache.cs
+++ b/src/MongoDbCache/MongoDbCache.cs
@@ -15,6 +15,12 @@ namespace MongoDbCache
 
         private void ValidateOptions(MongoDbCacheOptions cacheOptions)
         {
+            if (!string.IsNullOrEmpty(cacheOptions.ConnectionString) && cacheOptions.MongoClientSettings == null)
+            {
+                throw new ArgumentException(
+                    $"Only one of {nameof(cacheOptions.ConnectionString)} and {nameof(cacheOptions.MongoClientSettings)} can be set.");
+            }
+            
             if (string.IsNullOrEmpty(cacheOptions.ConnectionString) && cacheOptions.MongoClientSettings == null)
             {
                 throw new ArgumentException(

--- a/src/MongoDbCache/MongoDbCache.cs
+++ b/src/MongoDbCache/MongoDbCache.cs
@@ -15,10 +15,10 @@ namespace MongoDbCache
 
         private void ValidateOptions(MongoDbCacheOptions cacheOptions)
         {
-            if (string.IsNullOrEmpty(cacheOptions.ConnectionString))
+            if (string.IsNullOrEmpty(cacheOptions.ConnectionString) && cacheOptions.MongoClientSettings == null)
             {
                 throw new ArgumentException(
-                    $"{nameof(cacheOptions.ConnectionString)} cannot be empty or null.");
+                    $"{nameof(cacheOptions.ConnectionString)} or {nameof(cacheOptions.MongoClientSettings)} cannot be empty or null.");
             }
 
             if (string.IsNullOrEmpty(cacheOptions.DatabaseName))
@@ -45,7 +45,7 @@ namespace MongoDbCache
         {
             var options = optionsAccessor.Value;
             ValidateOptions(options);
-            _mongoContext = new MongoContext(options.ConnectionString, options.DatabaseName, options.CollectionName);
+            _mongoContext = new MongoContext(options.ConnectionString, options.MongoClientSettings, options.DatabaseName, options.CollectionName);
             SetScanInterval(options.ExpiredScanInterval);
         }
 

--- a/src/MongoDbCache/MongoDbCacheOptions.cs
+++ b/src/MongoDbCache/MongoDbCacheOptions.cs
@@ -1,11 +1,13 @@
 using System;
 using Microsoft.Extensions.Options;
+using MongoDB.Driver;
 
 namespace MongoDbCache
 {
     public class MongoDbCacheOptions : IOptions<MongoDbCacheOptions>
     {
         public string ConnectionString { get; set; }
+        public MongoClientSettings MongoClientSettings { get; set; }
         public string DatabaseName { get; set; }
         public string CollectionName { get; set; }
         public TimeSpan? ExpiredScanInterval { get; set; }


### PR DESCRIPTION
Allows the MongoDbCache to be configured by passing in MongoClientSettings, which are then passed to the MongoClient to allow additional configuration which cannot be added with the connection string.

Also added an environment variable flag to the tests to use MongoClientSettings instead of the connection string.